### PR TITLE
Override trait resetPassword because hashing is done in the User model

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -3,7 +3,9 @@
 namespace fuma\Http\Controllers\Auth;
 
 use fuma\Http\Controllers\Controller;
+use Illuminate\Support\Str;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Auth\Events\PasswordReset;
 
 class ResetPasswordController extends Controller
 {
@@ -35,5 +37,26 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    /**
+     * Reset the given user's password but dodn't has the password here 
+     * hashing is done in the User model.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $password
+     * @return void
+     */
+    protected function resetPassword($user, $password)
+    {
+        $user->password = $password;
+
+        $user->setRememberToken(Str::random(60));
+
+        $user->save();
+
+        event(new PasswordReset($user));
+
+        $this->guard()->login($user);
     }
 }


### PR DESCRIPTION
This fixes the double password hashing that is breaking Reset password. 

It was my mistake in the Roles/Permissions upgrade - I concentrated the password hash(bcrypt) step in the `User` model but didn't realise that it was also being done separately in the `ResetPasswordController`. This controller uses the functions in `ResetsPasswords` including `resetPassword` that was hashing the password. Overriding this function in the `ResetPasswordController` addresses this issue.

Perhaps this should be revisited again in the future. The reason for placing the bcrypt in the `User` model was not to have to repeat it in multiple places as this had lead to errors in the past. We need to check again what the Laravel best practice is here and it's more than likely that Laravel version 10 is different again.