### PR TITLE
Fixed problem with conditional filtering in RDB of eQTL

### DIFF
--- a/scripts/genemap/geneMap.R
+++ b/scripts/genemap/geneMap.R
@@ -207,7 +207,7 @@ if(eqtlMap==1){
 				eqtl <- eqtl[eqtl$uniqID %in% annot$uniqID[annot$CADD>=eqtlMapCADDth],]
 			}
 			if(eqtlMapRDBth!="NA"){
-				eqtl <- eqtl[eqtl$uniqID %in% eqtl$uniqID[annot$RDB<=eqtlMapRDBth],]
+				eqtl <- eqtl[eqtl$uniqID %in% annot$uniqID[annot$RDB<=eqtlMapRDBth],]
 			}
 			if(eqtlMapChr15!="NA"){
 				if(grepl("all", eqtlMapChr15)){


### PR DESCRIPTION
Hi I'm Khoa from this [FUMA's users conversation](https://groups.google.com/g/fuma-gwas-users/c/gPbZUT8XqmQ). 


TL;DR: I fixed the conditional filtering problem in eQTL but I also found another bug in CI mapping, causing inconsistent gene results between ci.txt and genes.txt

## Background information
So from the source code, I inspected all similarly buggy lines in geneMap.R and tried to fix based on the "merge-first" approach Tanya Phung said (took me 2 days can't believe it). But turns out it could be easily fixed by changing the data.table being filtered to annot. I can confirm to you this is the only line causing the problem mentioned before. 

Before
```
eqtl <- eqtl[eqtl$uniqID %in% **eqtl**$uniqID[annot$RDB<=eqtlMapRDBth],]
```

After
```
eqtl <- eqtl[eqtl$uniqID %in% **annot**$uniqID[annot$RDB<=eqtlMapRDBth],]
```

## Plot twist
Turns out the CI mapping also has another problem leading to inconsistency between ciMapFilt flag in ci.txt and ciMap ("Yes", "No"). For details please take a look at the quart-rendered html file

## Set up
In order to test the bug, I used one job with RDB filtering for eQTL and CI (`w_filter` dir), and another without filtering (`unprocessed` dir). You can find below my entire directory to run and inspect the bug. I use the unfiltered job for construction of ENSG, and gene_score file, and the params.config from filtered job to re-run the mapping process after fixing the code (old.params.config was the original config of the unfiltered job). The final result is presented in a quarto html for your ease of review. 

## Testing folder
[fuma_dev.zip](https://github.com/user-attachments/files/21467946/fuma_dev.zip)

../
├── genemap
│   ├── 01_preprocessing.qmd
│   ├── 02_check_results.html
│   ├── 02_check_results.qmd
│   ├── ConfigParser.R
│   ├── Dockerfile-genemap
│   ├── app.config
│   ├── geneMap.R
│   └── v110
│       ├── gene_scores.txt
│       └── unprocessed.ENSG.genes.txt
├── unprocessed
└── w_filter

### Description 
- 01_preprocessing.qmd was used to construct ENSG and gene_scores.txt file stored in v110 dir
- geneMap.R
- 02_check_results.qmd and html for checking the results
- I think you know the rest files


