### PR TITLE
Fix my_glob crash from macOS resource fork files

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -65,13 +65,22 @@ class Helper
      */
     public static function my_glob($filedir, $pattern)
     {
-        // list all filenames in given path
-        $allFiles = Storage::files($filedir);
+        try {
+            $allFiles = Storage::files($filedir);
+        } catch (\League\Flysystem\UnableToListContents $e) {
+            $diskRoot = Storage::path('');
+            $absDir = $diskRoot . ltrim($filedir, '/');
+            $allFiles = [];
+            foreach (scandir($absDir) as $f) {
+                if ($f === '.' || $f === '..' || str_starts_with($f, '._')) {
+                    continue;
+                }
+                $allFiles[] = rtrim($filedir, '/') . '/' . $f;
+            }
+        }
 
-        // filter the ones that match the filename.* 
         $matchingFiles = preg_grep($pattern, $allFiles);
         $matchingFiles = array_values($matchingFiles);
-        // return the matching filenames
         return $matchingFiles;
     }
 


### PR DESCRIPTION
## Summary
- `Helper::my_glob()` crashes with `UnableToListContents` when macOS `._` (AppleDouble/resource fork) files exist in the job directory — these files can't be stat'd by Flysystem's `LocalFilesystemAdapter`
- Adds a fallback to native `scandir()` that skips `._*` files, preserving the Storage-relative path format all callers expect
- The try/catch only triggers when Flysystem already fails, so zero impact on normal operation

This affects anyone running FUMA locally on macOS, particularly with external volumes (e.g. USB drives) where `._` files are common. The visible symptom is a "JobQuery MAGMA_expPlot error" alert on SNP2GENE results pages.

## Test plan
- [x] Created `._test_file` in a job directory, confirmed MAGMA expression plot renders without error
- [x] Removed test file, confirmed normal operation unaffected
- [x] Verified all `my_glob` callers (S2GController, CellController, FumaController) receive paths in the same format

🤖 Generated with [Claude Code](https://claude.com/claude-code)